### PR TITLE
Circular hatch - choose center

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Options:
   -x, --invert                    Invert the image (and levels) before
                                   applying thresholds.
   -c, --circular                  Use circular instead of diagonal hatches.
+  -o, --center                    Origin of circles relative to the image size.
+                                  For example, (0.5, 0.5) corresponds to the 
+                                  center of the image.
   -a, --angle                     Angle for diagonal hatches (in degrees)
   -d, --show-plot                 Display the contours and resulting pattern
                                   using matplotlib.
@@ -107,6 +110,7 @@ Call the function `hatched.hatch()` to process your image. It takes the followin
 - `h_mirror`: apply horizontal mirror on the image if True
 - `invert`: invert pixel value of the input image before processing (in this case, the level thresholds are inverted as well)
 - `circular`: use circular hatching instead of diagonal
+- `center`: relative position of cirles' center when using circular hatching
 - `hatch_angle`: hatching angle for diagonal hatches (in degrees)
 - `show_plot`: (default True) display contours and final results with matplotlib
 - `save_svg`: (default True) controls whether or not an output SVG file is created 

--- a/hatched/hatched.py
+++ b/hatched/hatched.py
@@ -278,7 +278,7 @@ def hatch(
     :param invert: invert pixel value of the input image before processing (in this case, the
         level thresholds are inverted as well)
     :param circular: use circular hatching instead of diagonal
-    :param center: relative x and y position for the center of circles for using circular
+    :param center: relative x and y position for the center of circles when using circular
         hatching. Defaults to (0.5, 0.5) corresponding to the center of the image
     :param hatch_angle: angle that defines hatching inclination (degrees)
     :param show_plot: display contours and final results with matplotlib

--- a/hatched/hatched.py
+++ b/hatched/hatched.py
@@ -13,12 +13,15 @@ from shapely.geometry import asMultiLineString, Polygon, LinearRing, MultiLineSt
 from skimage import measure
 
 
-def _build_circular_hatch(delta: float, offset: float, w: int, h: int):
-    center_x = w / 2
-    center_y = h / 2
+def _build_circular_hatch(delta: float, offset: float, w: int, h: int, center: Tuple[float,float] = (0.5, 0.5)):
+    center_x = w * center[0]
+    center_y = h * center[1]
 
     ls = []
-    for r in np.arange(offset, math.sqrt(w * w + h * h), delta):
+    # If center_x or center_y > 1, ensure the full image is covered with lines
+    max_radius = max(math.sqrt(w**2 + h**2), math.sqrt(center_x**2  + center_y**2))
+    
+    for r in np.arange(offset, max_radius, delta):
         # make a tiny circle as point in the center
         if r == 0:
             r = 0.001
@@ -44,6 +47,7 @@ def _build_circular_hatch(delta: float, offset: float, w: int, h: int):
     # Crop the circle to the final dimension
     p = Polygon([(0, 0), (w, 0), (w, h), (0, h)])
     return mls.intersection(p)
+
 
 
 def _build_diagonal_hatch(delta: float, offset: float, w: int, h: int, angle: float = 45):
@@ -178,6 +182,7 @@ def _build_hatch(
     hatch_pitch: float = 5.0,
     levels: Tuple[int, int, int] = (64, 128, 192),
     circular: bool = False,
+    center: Tuple[float, float] = (0.5, 0.5),
     invert: bool = False,
     hatch_angle: float = 45,
 ) -> Tuple[MultiLineString, Any, Any, Any]:
@@ -206,6 +211,7 @@ def _build_hatch(
 
         extra_args = {}
         if circular:
+            extra_args["center"] = center
             build_func = _build_circular_hatch
         else:
             extra_args["angle"] = hatch_angle
@@ -252,6 +258,7 @@ def hatch(
     h_mirror: bool = False,
     invert: bool = False,
     circular: bool = False,
+    center: Tuple[float, float] = (0.5, 0.5),
     hatch_angle: float = 45,
     show_plot: bool = True,
     save_svg: bool = True,
@@ -270,6 +277,8 @@ def hatch(
     :param invert: invert pixel value of the input image before processing (in this case, the
         level thresholds are inverted as well)
     :param circular: use circular hatching instead of diagonal
+    :param center: relative x and y position for the center of circles for using circular
+        hatching. Defaults to (0.5, 0.5) corresponding to the center of the image
     :param hatch_angle: angle that defines hatching inclination (degrees)
     :param show_plot: display contours and final results with matplotlib
     :param save_svg: controls whether or not an output svg file is created
@@ -291,6 +300,7 @@ def hatch(
         levels=levels,
         invert=invert,
         circular=circular,
+        center=center,
         hatch_angle=hatch_angle,
     )
 

--- a/hatched/hatched.py
+++ b/hatched/hatched.py
@@ -13,14 +13,16 @@ from shapely.geometry import asMultiLineString, Polygon, LinearRing, MultiLineSt
 from skimage import measure
 
 
-def _build_circular_hatch(delta: float, offset: float, w: int, h: int, center: Tuple[float,float] = (0.5, 0.5)):
+def _build_circular_hatch(
+    delta: float, offset: float, w: int, h: int, center: Tuple[float, float] = (0.5, 0.5)
+):
     center_x = w * center[0]
     center_y = h * center[1]
 
     ls = []
     # If center_x or center_y > 1, ensure the full image is covered with lines
-    max_radius = max(math.sqrt(w**2 + h**2), math.sqrt(center_x**2  + center_y**2))
-    
+    max_radius = max(math.sqrt(w**2 + h**2), math.sqrt(center_x**2 + center_y**2))
+
     for r in np.arange(offset, max_radius, delta):
         # make a tiny circle as point in the center
         if r == 0:
@@ -47,7 +49,6 @@ def _build_circular_hatch(delta: float, offset: float, w: int, h: int, center: T
     # Crop the circle to the final dimension
     p = Polygon([(0, 0), (w, 0), (w, h), (0, h)])
     return mls.intersection(p)
-
 
 
 def _build_diagonal_hatch(delta: float, offset: float, w: int, h: int, angle: float = 45):

--- a/hatched/vpype_plugin.py
+++ b/hatched/vpype_plugin.py
@@ -48,6 +48,14 @@ import vpype as vp
     "-c", "--circular", is_flag=True, help="Use circular instead of diagonal hatches."
 )
 @click.option(
+    "-o",
+    "--center",
+    nargs=2,
+    type=float,
+    default=(0.5, 0.5),
+    help="Relative coordinates of the circles' origin for circular hatching. Defaults to (0.5, 0.5) for image center.",
+)
+@click.option(
     "-a",
     "--angle",
     default=45,
@@ -70,6 +78,7 @@ def hatched_gen(
     pitch: int,
     invert: bool,
     circular: bool,
+    center,
     angle: float,
     show_plot: bool,
 ):
@@ -97,6 +106,7 @@ def hatched_gen(
             hatch_pitch=pitch,
             invert=invert,
             circular=circular,
+            center=center,
             hatch_angle=angle,
             show_plot=show_plot,
             h_mirror=False,  # this is best handled by vpype


### PR DESCRIPTION
Receive the position of circles' origin as input for circular hatching

Example 1: cirles' center outside of the image at (1.1, 1.1)
<img width="252" alt="circular_skull" src="https://user-images.githubusercontent.com/57906928/154371039-391888f9-6b60-4cd8-b433-c9cb2097df88.PNG">

Example 2: circles' center inside the image at (0.2, 0.7)
<img width="260" alt="circular_skull2" src="https://user-images.githubusercontent.com/57906928/154371131-ffb9655c-f15a-4334-98b7-a23f515dcf9b.PNG">

