### PR TITLE
Fix Shapely MultiLineString input and horizontal hatching

### DIFF
--- a/hatched/hatched.py
+++ b/hatched/hatched.py
@@ -103,7 +103,7 @@ def _build_diagonal_hatch(delta: float, offset: float, w: int, h: int, angle: fl
                 stop = (w, j)
 
             lines.append([start, stop])
-    return np.array(lines)
+    return lines
 
 
 def _plot_poly(geom, colspec=""):
@@ -142,7 +142,9 @@ def _save_to_svg(file_path: str, w: int, h: int, vectors: Iterable[MultiLineStri
     dwg.add(
         dwg.path(
             " ".join(
-                " ".join(("M" + " L".join(f"{x},{y}" for x, y in ls.coords)) for ls in mls.geoms)
+                " ".join(
+                    ("M" + " L".join(f"{x},{y}" for x, y in ls.coords)) for ls in mls.geoms
+                )
                 for mls in vectors
             ),
             fill="none",
@@ -218,7 +220,7 @@ def _build_hatch(
             extra_args["angle"] = hatch_angle
             build_func = _build_diagonal_hatch
             # correct offset to ensure desired distance between hatches
-            if hatch_angle != 0:
+            if hatch_angle % 180 != 0:
                 hatch_pitch /= math.sin((hatch_angle % 180) * math.pi / 180)
 
         light_lines = build_func(4 * hatch_pitch, 0, w, h, **extra_args)
@@ -241,7 +243,9 @@ def _build_hatch(
 
     return (
         MultiLineString(
-            [ls for ls in light_mls.geoms] + [ls for ls in dark_mls.geoms] + [ls for ls in black_mls.geoms]
+            [ls for ls in light_mls.geoms]
+            + [ls for ls in dark_mls.geoms]
+            + [ls for ls in black_mls.geoms]
         ),
         black_cnt,
         dark_cnt,


### PR DESCRIPTION
- `MultiLineString` returns an error when passing a numpy array as input
- Horizontal hatching with angle different than 0 was returning a zero division when calculating the hatch pitch