### PR TITLE
Fix initialization of empty MultiLineStrings

### DIFF
--- a/hatched/hatched.py
+++ b/hatched/hatched.py
@@ -208,7 +208,7 @@ def _build_hatch(
     # Find contours at a constant value of 0.8
     contours = [measure.find_contours(r, levels[i]) for i in range(n_levels)]
 
-    mls = [MultiLineString(np.empty(shape=(0, 2, 2))) for i in range(n_levels)]
+    mls = [shapely.from_wkt("MULTILINESTRING EMPTY") for i in range(n_levels)]
 
     try:
         mask = [_build_mask(i) for i in contours[::-1]]


### PR DESCRIPTION
Seems like the API of numpy of shapely changed as the code relied on the truth value of an empty numpy array. This now raises an `ValueError: The truth value of an empty array is ambiguous`.

This PR will create empty `MultiLineString` instances directly, using the same API as the constructor of `shapely.MultiLineString` would.

Fixes #20.